### PR TITLE
CHANGE BODYTEXT1 TO BODYLARGE

### DIFF
--- a/lib/src/widgets/question_card.dart
+++ b/lib/src/widgets/question_card.dart
@@ -53,7 +53,7 @@ class QuestionCard extends StatelessWidget {
                     child: RichText(
                       text: TextSpan(
                           text: question.question,
-                          style: Theme.of(context).textTheme.bodyText1,
+                          style: Theme.of(context).textTheme.bodyLarge,
                           children: question.isMandatory
                               ? [
                                   const TextSpan(


### PR DESCRIPTION
In the last version of flutter ( on the date of this document) bodytext1 has been deprecated and should use bodylarge instead.
source : https://api.flutter.dev/flutter/material/TextTheme/bodyText1.html

If this isn't changed in the package, you can still fork the package on your own repo, solve the issue and use your own forked version of the package in your flutter app this way :
dependencies:
  some_package:
    git:
      url: https://github.com/your-username/the-package.git. // the package on your repo
      ref: master # Or a specific branch/tag/commit